### PR TITLE
Upgrade Gradle action in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         distribution: ${{ vars.UBUNTU_DISTRIBUTION }}
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v3
 
     - name: Build with Gradle Wrapper
       run: ./gradlew build --scan
@@ -49,7 +49,7 @@ jobs:
           distribution: ${{ vars.MACOS_DISTRIBUTION }}
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build with Gradle Wrapper
         run: ./gradlew build --scan
@@ -72,7 +72,7 @@ jobs:
           distribution: ${{ vars.WINDOWS_DISTRIBUTION }}
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build with Gradle Wrapper
         run: ./gradlew build --scan

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -26,4 +26,4 @@ jobs:
           distribution: ${{ vars.JAVA_DISTRIBUTION }}
 
       - name: Generate and submit dependency graph
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
           distribution: ${{ vars.JAVA_DISTRIBUTION }}
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Publish package
         run: ./gradlew publish


### PR DESCRIPTION
# Description
Replaces the outdated action `gradle/gradle-build-action@v3` with `gradle/actions/setup-gradle@v3`

Fixes #3 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
According to the documentation on the Gradle action and the warning generated: https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, if any
- [x] My changes generate no new warnings
- [x] I have performed tests that prove my fix is effective or that my feature works, if necessary
- [x] New and existing unit tests pass locally with my changes